### PR TITLE
fix: remove broken contextPruning and cache config keys

### DIFF
--- a/openclaw.json
+++ b/openclaw.json
@@ -16,13 +16,7 @@
         "every": "1h",
         "model": "fuel/heartbeat"
       },
-      "contextPruning": {
-        "mode": "cache-ttl",
-        "ttl": "6h",
-        "keepLastAssistants": 3
-      },
       "compaction": {
-        "mode": "default",
         "reserveTokensFloor": 20000,
         "memoryFlush": {
           "enabled": true,
@@ -35,11 +29,6 @@
         "enabled": true,
         "sources": ["memory", "sessions"],
         "provider": "local"
-      },
-      "cache": {
-        "enabled": true,
-        "ttl": "5m",
-        "priority": "high"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Remove `contextPruning` — not a valid OpenClaw config key, causes config rejection on startup
- Remove `cache` — same issue, crashes OpenClaw
- Remove `compaction.mode: "default"` — not needed, compaction works without it

These keys were already excluded from provisioned instances. This aligns the template repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)