### PR TITLE
fix: restore prompt caching config

### DIFF
--- a/openclaw.json
+++ b/openclaw.json
@@ -29,6 +29,11 @@
         "enabled": true,
         "sources": ["memory", "sessions"],
         "provider": "local"
+      },
+      "cache": {
+        "enabled": true,
+        "ttl": "5m",
+        "priority": "high"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Restore `cache` config under `agents.defaults` — valid OpenClaw setting for prompt caching
- Was incorrectly removed in #1 alongside the actually-broken `contextPruning` key
- Per the [Token Optimization Guide](https://openclaw.rocks), this enables 90% token discount on reused system prompts

`contextPruning` remains removed (not a valid config key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)